### PR TITLE
Improved heap evaluation descriptions

### DIFF
--- a/examples/multi_level_heap.hs
+++ b/examples/multi_level_heap.hs
@@ -1,0 +1,3 @@
+const = (\x -> \y -> x)
+
+main = (\x -> @const x x) ((\x -> @const x x) (@const 1 1))

--- a/src/CBN/Eval.hs
+++ b/src/CBN/Eval.hs
@@ -1,6 +1,7 @@
 module CBN.Eval (
     Error
   , Description(..)
+  , DescriptionWithContext(..)
   , Step(..)
   , step
   ) where
@@ -35,9 +36,11 @@ data Description =
   | StepSeq
   deriving (Show)
 
+data DescriptionWithContext = DescriptionWithContext Description [Ptr] deriving (Show)
+
 data Step =
     -- | Evaluation took a single step
-    Step Description (Heap Term, Term)
+    Step DescriptionWithContext (Heap Term, Term)
 
     -- | We have reached weak head normal form
   | WHNF Value
@@ -45,6 +48,13 @@ data Step =
     -- | The evaluator got stuck
   | Stuck Error
   deriving (Show)
+
+no_context :: Description -> (Heap Term, Term) -> Step
+no_context descr = Step (DescriptionWithContext descr [])
+
+add_context :: Ptr -> DescriptionWithContext -> (Heap Term, Term) -> Step
+add_context ptr (DescriptionWithContext descr context) = Step (DescriptionWithContext descr (ptr:context))
+
 
 -- | Single execution step (small step semantics)
 step :: (Heap Term, Term) -> Step
@@ -54,11 +64,11 @@ step (_, TCon ces)             = WHNF $ VCon ces
 step (_, TPrim (PrimApp p [])) = WHNF $ VPrim p
 step (hp, TPtr ptr) =
     case step (hp, deref (hp, ptr)) of
-      Step d (hp', e') -> Step d (mutate (hp', ptr) e', TPtr ptr)
+      Step d (hp', e') -> add_context ptr d (mutate (hp', ptr) e', TPtr ptr)
       Stuck err        -> Stuck err
       WHNF val         -> WHNF val
 step (hp, TLet x e1 e2) =
-    Step StepAlloc $ allocSubst RecBinding [(x,e1)] (hp, e2)
+    no_context StepAlloc $ allocSubst RecBinding [(x,e1)] (hp, e2)
 step (hp, TApp e1 e2) = do
     let descr = case e1 of
                   TPtr ptr   -> StepApply ptr
@@ -66,7 +76,7 @@ step (hp, TApp e1 e2) = do
     case step (hp, e1) of
       Step d (hp', e1') -> Step d (hp', TApp e1' e2)
       Stuck err         -> Stuck err
-      WHNF (VLam x e1') -> Step descr $ allocSubst NonRecBinding [(x,e2)] (hp, e1')
+      WHNF (VLam x e1') -> no_context descr $ allocSubst NonRecBinding [(x,e2)] (hp, e1')
       WHNF _            -> Stuck "expected lambda"
 step (hp, TCase e ms) =
     case step (hp, e) of
@@ -79,7 +89,7 @@ step (hp, TCase e ms) =
           Nothing -> Stuck "Non-exhaustive pattern match"
           Just (xs, e') ->
             if length xs == length es
-              then Step (StepMatch c) $ allocSubst NonRecBinding (zip xs es) (hp, e')
+              then no_context (StepMatch c) $ allocSubst NonRecBinding (zip xs es) (hp, e')
               else Stuck $ "Invalid pattern match (cannot match " ++ show (xs, es) ++ ")"
 step (hp, TPrim (PrimApp p es)) =
     case stepPrimArgs hp es of
@@ -87,25 +97,25 @@ step (hp, TPrim (PrimApp p es)) =
       PrimWHNF vs        -> let descr = StepDelta (PrimApp p (map (valueToTerm . VPrim) vs))
                             in case delta p vs of
                               Left err -> Stuck err
-                              Right e' -> Step descr (hp, valueToTerm e')
+                              Right e' -> no_context descr (hp, valueToTerm e')
       PrimStuck err      -> Stuck err
 step (hp, TIf c t f) =
     case step (hp, c) of
       Step d (hp', c') -> Step d (hp', TIf c' t f)
       Stuck err        -> Stuck err
-      WHNF val | val == liftBool True  -> Step (StepIf True)  (hp, t)
-               | val == liftBool False -> Step (StepIf False) (hp, f)
+      WHNF val | val == liftBool True  -> no_context (StepIf True)  (hp, t)
+               | val == liftBool False -> no_context (StepIf False) (hp, f)
                | otherwise             -> Stuck "expected bool"
 step (hp, TSeq e1 e2) =
     case step (hp, e1) of
       Step d (hp', e1') -> Step d (hp', TSeq e1' e2)
       Stuck err         -> Stuck err
-      WHNF _            -> Step StepSeq (hp, e2)
+      WHNF _            -> no_context StepSeq (hp, e2)
 
 -- | The result of stepping the arguments to an n-ary primitive function
 data StepPrimArgs =
     -- Some term took a step
-    PrimStep Description (Heap Term) [Term]
+    PrimStep DescriptionWithContext (Heap Term) [Term]
 
     -- All terms were already in WHNF
   | PrimWHNF [Prim]

--- a/src/CBN/Pretty.hs
+++ b/src/CBN/Pretty.hs
@@ -160,6 +160,16 @@ instance ToDoc Description where
   toDoc (StepIf b)      = doc "if"     <+> doc (show b)
   toDoc StepSeq         = doc "seq"
 
+-- | Based on purescript implementation
+mintersperse :: (Monoid m) => m -> [m] -> m
+mintersperse _ []       = mempty
+mintersperse _ [x]      = x
+mintersperse sep (x:xs) = x <> sep <> mintersperse sep xs
+
+instance ToDoc DescriptionWithContext where
+  toDoc (DescriptionWithContext descr []) = toDoc descr
+  toDoc (DescriptionWithContext descr context) = toDoc descr <> doc " in " <> (mintersperse (doc " in ") . map toDoc $ reverse context)
+
 -- | For the heap we need to know which pointers we are about to collect
 heapToDoc :: forall a. ToDoc a => Set Ptr -> Heap a -> Doc Style String
 heapToDoc garbage (Heap _next heap) =

--- a/src/CBN/Trace/JavaScript.hs
+++ b/src/CBN/Trace/JavaScript.hs
@@ -48,7 +48,7 @@ render name = \tr ->
     mkErr :: String -> String
     mkErr = ("error: " ++)
 
-    mkDesc :: Description -> String
+    mkDesc :: DescriptionWithContext -> String
     mkDesc d = "next step: " ++ pretty d
 
     set :: String -> String -> String


### PR DESCRIPTION
When evaluation happens in a heap- rather than top-level-expression,
put the location in the description.

Example:
```
  x_0 = x_1
  x_1 = const 1 1
  x_0

  (apply const in x_1 in x_0)
```
There are a bunch of quality issues with this commit:

* The "in x in y in z" output isn't very elegant.
  * Maybe a stack-trace like representation would be better?
  * Maybe only writing the name of the pointer where the actual change happens would be better? (No "in-chain")
* It might be helpful for some (or overwhelming for others?) if every recursive `eval` call can be found in the description/stack trace. But I guess a chain of "in eval of TCase in eval of TIf ..." wouldn't help, so a tree structure with named nodes would be somewhat cool ...
  * Maybe that could be added but hidden behind a switch just like the `summarize` options?
* Admittedly, I didn't put much thought into the design. `DescriptionWithContext` is awkward. `no_context` and `add_context` are even more so?
* Should I actually add the multi_level_heap.hs example? I added it as a kind of test-case, but it isn't very helpful as an example.