### PR TITLE
A few simple changes

### DIFF
--- a/src/CBN/Util/Snoc.hs
+++ b/src/CBN/Util/Snoc.hs
@@ -13,8 +13,4 @@ data Snoc a = Nil | Cons (Snoc a) a
   deriving (Show, Eq, Ord)
 
 fromList :: [a] -> Snoc a
-fromList = go Nil
-  where
-    go :: Snoc a -> [a] -> Snoc a
-    go acc []     = acc
-    go acc (x:xs) = go (Cons acc x) xs
+fromList = foldl Cons Nil

--- a/visualize-cbn.cabal
+++ b/visualize-cbn.cabal
@@ -48,7 +48,6 @@ executable visualize-cbn
                      , blaze-markup         >= 0.7  && < 0.9
                      , containers           >= 0.5  && < 0.6
                      , data-default         >= 0.7  && < 0.8
-                     , mtl                  >= 2.2  && < 2.3
                      , optparse-applicative >= 0.12 && < 0.15
                      , parsec               >= 3.1  && < 3.2
                        -- version shipped with ghc


### PR DESCRIPTION
- remove the unused build dependency on `mtl'.
- refactor CBN.Util.Snoc.fromList to use the `foldl' from prelude.
