### PR TITLE
Print a more meaningful error message when the heap ptr deref fail

### DIFF
--- a/src/CBN/Heap.hs
+++ b/src/CBN/Heap.hs
@@ -10,6 +10,7 @@ module CBN.Heap (
   , alloc
   , mutate
   , initHeap
+  , pprintPtr
     -- * Garbage collection
   , Pointers(..)
   , markAndSweep
@@ -43,6 +44,11 @@ import qualified Data.Graph    as Graph
 data Ptr = Ptr (Maybe Int) (Maybe String)
   deriving (Show, Eq, Ord, Data)
 
+pprintPtr :: Ptr -> String
+pprintPtr (Ptr _        Nothing)   = ""
+pprintPtr (Ptr Nothing  (Just s))  = "@" ++ s
+pprintPtr (Ptr (Just _) (Just s))  = s
+
 -- | Heap
 --
 -- NOTE: We will use the convention that if a particular term or pointer is
@@ -73,9 +79,8 @@ alloc name (Heap next hp) e =
     ptr :: Ptr
     ptr = Ptr (Just next) name
 
-deref :: (Heap a, Ptr) -> a
-deref (Heap _ hp, ptr) =
-    Map.findWithDefault (error $ "deref: invalid pointer " ++ show ptr) ptr hp
+deref :: (Heap a, Ptr) -> Maybe a
+deref (Heap _ hp, ptr) = Map.lookup ptr hp
 
 mutate :: (Heap a, Ptr) -> a -> Heap a
 mutate (Heap next hp, ptr) term = Heap next (Map.insert ptr term hp)


### PR DESCRIPTION
This change addresses the #1 where the printed error message is confusing in the case
of the dereferencing failure. 

In case of a pointer dereferencing failure, the error message also prints all the valid
heap pointers. However, this is still not very meaningful when the programmer misses
out an '@' symbol while referring to a heap pointer.

examples: in the `examples/take.hs`, if we make the following change:
```
-main = @take 1 (@enumFromTo 1 10)
+main = @take 1 (@enumFrom 1 10)
```
The error message printed at the end is:
```
...
(stuck: Invalid reference to symbol "enumFrom". Valid symbol names are: ["enumFromTo","take"])
```
However, for the example given in #1, it prints a not so useful error message:
```
(stuck: Invalid reference to symbol "res". Valid symbol names are: ["span","p","xs","ys"])
```
I still feel it is a slight improvement over the initial implementation. Error messages are hard!