### PR TITLE
Term graph

### DIFF
--- a/examples/graph.hs
+++ b/examples/graph.hs
@@ -1,0 +1,5 @@
+ls = (Cons 1 (Cons 2 (Cons 3 @ls)))
+
+double = (\n -> add n n)
+
+main = @double (add 1 2)

--- a/minimal.html
+++ b/minimal.html
@@ -1,4 +1,5 @@
 <html>
+
 <body>
 
 <a onclick="cbnPrev()">Prev</a>
@@ -8,6 +9,7 @@
 <table width="100%" border="1" cellpadding="5" style="border-collapse: collapse;">
 <tr><td><div style="font-family: monospace;" id="cbn_term">Term</div></td></tr>
 <tr><td><div style="font-family: monospace;" id="cbn_heap">Heap</div></td></tr>
+<tr><td><div id="cbn_graph">Graph</div></td></tr>
 </table>
 
 <script type="text/javascript" src="foo.js"></script>

--- a/src/CBN/Closure.hs
+++ b/src/CBN/Closure.hs
@@ -1,0 +1,118 @@
+module CBN.Closure (toClosureGraph, Closure(..), Id) where
+
+import Data.Maybe (fromJust)
+import Data.Graph as Graph
+import Control.Monad.State
+import qualified Data.Set as Set
+import qualified Data.Map as Map
+import qualified Data.Tree as Tree
+
+import CBN.Language
+import CBN.Heap
+import CBN.Trace
+
+-- Some Terms have a heap Pointer, but not an explicit CBN.Heap.Ptr.
+-- For example the closure `Cons 1 Nil` has a Pointer to `1`
+-- and to `Nil`. All values are assumed boxed.
+
+-- | Id is the unique id of each node.
+data Id = Id Ptr Int
+ deriving (Eq, Ord)
+
+-- | The Id for objects with an explicit Heap.Ptr.
+defaultId :: Ptr -> Id
+defaultId p = Id p 0
+
+-- | Each Closure has a Header and some edges (the Payload).
+data Closure =
+    ErrorClosure String
+  | FunClosure Term [Ptr]
+  | ConClosure Con [Term]
+
+  -- IndirectionClosures can be ignored while looking at the graph.
+  -- An idirection of a thunk is a thunk and an indirection to a
+  -- whnf is whnf. Indirections are not yet eliminated because they can
+  -- have loops, so this task is not trivial.
+  | IndirectionClosure Ptr
+
+  -- ThunkClosure also includes Closures for function application.
+  -- This could be improved in the future. See also:
+  -- https://ghc.haskell.org/trac/ghc/wiki/Commentary/Rts/Storage/HeapObjects#Genericapplication
+  | ThunkClosure Term [Ptr]
+  | PrimClosure Prim [Term]
+  deriving (Show)
+
+-- | Eventually all edges are heap pointers. The distinction here is made
+-- because related terms don`t have an assigned Id when this function is used.
+extractEdges :: Closure -> ([Ptr], [Term])
+extractEdges cl = case cl of
+  ErrorClosure _ -> ([], [])
+  FunClosure _ ls -> (ls, [])
+  ConClosure _ ls -> ([], ls)
+  IndirectionClosure ptr -> ([ptr], [])
+  ThunkClosure _ ls -> (ls, [])
+  PrimClosure _ ls -> ([], ls)
+
+thunk :: Term -> Closure
+thunk term = ThunkClosure term $ Set.toList $ pointers term
+
+-- Heap could be used in the future to eliminate Indirections.
+
+toClosure :: (Heap Term, Term) -> Closure
+toClosure (heap, term) = case term of
+  TVar (Var x) -> ErrorClosure $ "free variable " ++ show x
+  TLam _ _ -> FunClosure term ls
+    where ls = Set.toList $ pointers term
+  TCon (ConApp con terms) -> ConClosure con terms
+  TPtr ptr -> IndirectionClosure ptr
+  TPrim (PrimApp p es) -> PrimClosure p es
+  TLet _ _ _ -> thunk term
+  TApp _ _ -> thunk term
+  TCase _ _ -> thunk term
+  TIf _ _ _ -> thunk term
+  TSeq _ _ -> thunk term
+
+-- | Build a representation of the heap, including terms that don`t
+-- have an explicit Heap.Ptr.
+toClosureGraph :: (Heap Term, Term) -> (Graph, Graph.Vertex ->
+  (Closure, Id, [Id]), Id -> Graph.Vertex)
+toClosureGraph (heap@(Heap _ hp), term) =
+  let (graph, f, g) = Graph.graphFromEdges edges
+  in (graph, f , fromJust . g)
+  where
+    main = (Ptr Nothing (Just "main"), term)
+
+    edges :: [(Closure, Id, [Id])]
+    edges = concatMap mkTree $ main : Map.toList hp
+
+    -- If we ignore Heap.Ptrs, each heap term, defines a tree of other reachable
+    -- terms.
+    mkTree :: (Ptr, Term) -> [(Closure, Id, [Id])]
+    mkTree (ptr, term) = Tree.flatten $ addInternalEdges tree
+      where
+        identify :: State Int Id
+        identify = do
+          myid <- get
+          put $ myid + 1
+          return $ Id ptr myid
+
+        addInternalEdges :: Tree (Id, (Closure, [Id])) -> Tree (Closure, Id, [Id])
+        addInternalEdges (Node (myid, (cl, ids)) subTrees) = Node (cl, myid, newIds) cont
+          where
+            childIds = fmap (fst . Tree.rootLabel) subTrees
+            newIds = ids ++ childIds
+            cont = map addInternalEdges subTrees
+
+        tree :: Tree (Id, (Closure, [Id]))
+        tree = evalState (Tree.unfoldTreeM f term) 0
+
+        -- The [Id] here contains only the pointer ids and
+        -- Not the Ids of the same Tree, as those are not assigned yet.
+        -- They are added  at `addInternalEdges`, after the creation of the whole tree.
+
+        f :: Term -> State Int ((Id, (Closure, [Id])), [Term])
+        f term = do
+          myid <- identify
+          let closure = toClosure (heap, term)
+          let (ptrs, terms) = extractEdges closure
+          return ((myid, (closure, map defaultId ptrs)), terms)

--- a/src/CBN/Options.hs
+++ b/src/CBN/Options.hs
@@ -14,6 +14,7 @@ data Options = Options {
     , optionsJsOutput    :: Maybe FilePath
     , optionsJsName      :: String
     , optionsGraphOutput :: Maybe FilePath
+    , optionsGraphTermsOutput :: Maybe FilePath
     }
   deriving (Show)
 
@@ -52,6 +53,11 @@ parseOptions = Options
              long "graph"
            , help "Generate a graph output in dot format"
            , metavar "GRAPH-FILE"
+           ])
+    <*> (optional . strOption $ mconcat [
+             long "heap-graph"
+           , help "Generate one graph representation file for each step"
+           , metavar "PATH/FILES-PREFIX"
            ])
 
 parseSummarizeOptions :: Parser SummarizeOptions

--- a/src/CBN/Pretty.hs
+++ b/src/CBN/Pretty.hs
@@ -6,6 +6,7 @@ import Data.Set (Set)
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 
+import CBN.Closure
 import CBN.Eval
 import CBN.Heap
 import CBN.Language
@@ -150,6 +151,15 @@ instance ToDoc Term where
       c' = toDoc' Top    c
       t' = toDoc' (R If) t
       f' = toDoc' (R If) f
+
+instance ToDoc Closure where
+  toDoc cl = case cl of
+    ErrorClosure str -> doc "Error :" <+> doc str
+    FunClosure term _ -> doc "Funtion :" <+> toDoc term
+    ConClosure con _ -> doc "Constructor :" <+> toDoc con
+    IndirectionClosure _ -> doc "Indirection " -- <+> toDoc ptr
+    ThunkClosure term _ -> doc "Thunk :" <+> toDoc term
+    PrimClosure prim _ -> doc "Primary :" <+> toDoc prim
 
 instance ToDoc Description where
   toDoc StepAlloc       = doc "allocate"

--- a/src/CBN/Pretty.hs
+++ b/src/CBN/Pretty.hs
@@ -155,7 +155,7 @@ instance ToDoc Term where
 instance ToDoc Closure where
   toDoc cl = case cl of
     ErrorClosure str -> doc "Error :" <+> doc str
-    FunClosure term _ -> doc "Funtion :" <+> toDoc term
+    FunClosure term _ -> doc "Function :" <+> toDoc term
     ConClosure con _ -> doc "Constructor :" <+> toDoc con
     IndirectionClosure _ -> doc "Indirection " -- <+> toDoc ptr
     ThunkClosure term _ -> doc "Thunk :" <+> toDoc term

--- a/src/CBN/Trace/HeapGraph.hs
+++ b/src/CBN/Trace/HeapGraph.hs
@@ -1,0 +1,92 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- This module was inspired by CBN.Trace.Graph and has a lot of code repetition.
+
+module CBN.Trace.HeapGraph (toGraphFiles) where
+
+import Control.Monad
+import Data.Graph (Graph)
+import Data.Monoid ((<>))
+import qualified Data.Graph as Graph
+import qualified Data.Text as T
+
+import CBN.Closure
+import CBN.Pretty
+import CBN.Trace
+import CBN.Util.Doc.Style
+import qualified CBN.Util.Doc          as Doc
+import qualified CBN.Util.Doc.Rendered as Rendered
+
+toGraphFiles :: Trace -> FilePath -> IO ()
+toGraphFiles trace pathAndPrefix = forM_ (renderMemoryTrace trace) $
+  \(k,v) -> writeFile (pathAndPrefix ++ show k ++ ".dot") v
+
+renderMemoryTrace :: Trace -> [(Int,String)]
+renderMemoryTrace = go 0
+  where
+    go n (Trace (hp, t) cont) = (n,x):xs
+      where
+        x = renderMemoryGraph $ toClosureGraph (hp, t)
+        xs = case cont of
+          TraceStep _ tr' -> go (n + 1) tr'
+          TraceGC _ tr'  -> go (n + 1) tr'
+          _               -> []
+
+renderMemoryGraph :: (Graph, Graph.Vertex ->
+ (Closure, Id, [Id]), Id -> Graph.Vertex) -> String
+renderMemoryGraph (graph, f, g) =
+  "digraph G {\n"
+  ++ "node [ fontname=monospace, shape=plaintext ];\n"
+  ++ concatMap mkFrame (Graph.vertices graph)
+  ++ "}"
+  where
+    mkFrame :: Graph.Vertex -> String
+    mkFrame vertex =
+      let (closure, _, ids) = f vertex
+          rows :: T.Text
+          rows = mkRow (pretty closure)
+      in T.unpack $
+        setLabel vertex ("<<TABLE ALIGN=\"LEFT\">" <> rows <> "</TABLE>>")
+        <> "\n"
+        <> mkConnections vertex (map g ids)
+
+    mkRow :: T.Text -> T.Text
+    mkRow content = "<TR><TD BALIGN=\"LEFT\" ALIGN=\"LEFT\">" <> content <> "</TD></TR>"
+
+    setLabel :: Graph.Vertex -> T.Text -> T.Text
+    setLabel n label = mkNode n <> "[label=" <> label <> "];"
+
+    mkConnections :: Graph.Vertex -> [Graph.Vertex] -> T.Text
+    mkConnections n [] = mkNode n <> ";\n"
+    mkConnections n adj = mkNode n <> " -> " <> T.intercalate ", " (map mkNode adj) <> ";\n"
+
+    mkNode :: Graph.Vertex -> T.Text
+    mkNode n = "s" <> T.pack (show n)
+
+    pretty :: ToDoc a => a -> T.Text
+    pretty = T.pack . goRendered . Rendered.rendered . Doc.render (\r -> Rendered.width r <= 80) . toDoc
+
+    goRendered :: [[Maybe (Style, Char)]] -> String
+    goRendered []       = ""
+    goRendered (row:xs) = goRow row ++ "<BR />" ++ goRendered xs
+
+    goRow :: [Maybe (Style, Char)] -> String
+    goRow = mconcat . map toDotHtml . groupByStyle
+
+    toDotHtml :: (Style, String) -> String
+    toDotHtml (Style Nothing _ True _, str) = "<B>" <> escapeChars str <> "</B>"
+    toDotHtml (Style Nothing _ _ True, str) = "<I>" <> escapeChars str <> "</I>"
+    toDotHtml (Style (Just fg) _ _ _, str) =
+      let color = case fg of Blue -> "blue"; Red -> "red"
+      in
+        "<FONT COLOR=\"" <> color <> "\">" <> escapeChars str <> "</FONT>"
+    toDotHtml (Style Nothing _ False False, str) = escapeChars str
+
+    escapeChars :: String -> String
+    escapeChars =
+      T.unpack
+      . T.replace "\n" "<BR />"
+      . T.replace ">" "&gt;"
+      . T.replace "<" "&lt;"
+      . T.replace " " "&nbsp;"
+      . T.pack

--- a/src/CBN/Trace/JavaScript.hs
+++ b/src/CBN/Trace/JavaScript.hs
@@ -13,10 +13,11 @@ import CBN.Util.Doc.Rendered.HTML ()
 import qualified CBN.Util.Doc          as Doc
 import qualified CBN.Util.Doc.Rendered as Rendered
 
-render :: String -> Trace -> String
-render name = \tr ->
+render :: String -> Maybe FilePath -> Trace -> String
+render name graph = \tr ->
        "function " ++ name ++ "(frame) {\n"
     ++ innerHTML "step" ++ " = frame;\n"
+    ++ mkGraph
     ++ go 0 tr
     ++ "}\n"
     ++ "var " ++ name ++ "_frame = 0;\n"
@@ -28,6 +29,13 @@ render name = \tr ->
     ++ "}\n"
     ++ name ++ "(" ++ name ++ "_frame);\n"
   where
+    mkGraph :: String
+    mkGraph = case graph of
+      Nothing -> ""
+      Just g  ->
+        innerHTML "graph" ++ " = \'<img src=\\'"
+        ++ g ++ "' + frame.toString() + '.png\\'>';\n"
+
     go :: Int -> Trace -> String
     go n (Trace (hp, e) c) =
         case c of

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,10 +1,11 @@
-module Main (main) where
+  module Main (main) where
 
 import Control.Monad
 
 import CBN.Options
 import CBN.Parser
 import CBN.Trace
+import CBN.Trace.HeapGraph  as Trace.HeapGraph
 import CBN.Trace.JavaScript as Trace.JavaScript
 import CBN.Trace.Textual    as Trace.Textual
 import CBN.Trace.Graph      as Trace.Graph
@@ -17,6 +18,7 @@ main = do
     when optionsShowTrace $      
       Trace.Textual.renderIO trace
     forM_ optionsJsOutput $ \file ->
-      writeFile file $ Trace.JavaScript.render optionsJsName trace
+      writeFile file $ Trace.JavaScript.render optionsJsName optionsGraphOutput trace
     forM_ optionsGraphOutput $ \file ->
       writeFile file $ Trace.Graph.render trace
+    forM_ optionsGraphOutput $ toGraphFiles trace

--- a/visualize-cbn.cabal
+++ b/visualize-cbn.cabal
@@ -30,6 +30,7 @@ executable visualize-cbn
                        CBN.Pretty.Precedence
                        CBN.Subst
                        CBN.Trace
+                       CBN.Trace.HeapGraph
                        CBN.Trace.JavaScript
                        CBN.Trace.Textual
                        CBN.Trace.Graph

--- a/visualize-cbn.cabal
+++ b/visualize-cbn.cabal
@@ -19,7 +19,8 @@ source-repository head
 
 executable visualize-cbn
   main-is:             Main.hs
-  other-modules:       CBN.Eval
+  other-modules:       CBN.Closure
+                       CBN.Eval
                        CBN.Free
                        CBN.Heap
                        CBN.Language
@@ -50,6 +51,7 @@ executable visualize-cbn
                      , parsec               >= 3.1  && < 3.2
                        -- version shipped with ghc
                      , template-haskell
+                     , mtl
                      , text
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
Related Issue #2 
This PR adds the option of visualizing the heap as a graph.

- Module Closure is pure and can be used by any visual backend to visualize the graph.
- Dot is used for representing the graphs (same as #11).
- For each step a new dot file is created. Dot files must be rendered to png to be used by javascript.
- Nodes of the graph include not only named heap pointers, but also every term that would be represented as a separate heap object.
- Edges of a Closure point towards its free variables and other heap objects.


A step of examples/skim.hs:

![skim](https://user-images.githubusercontent.com/11467473/38509870-7542151c-3c23-11e8-87a5-60f5b84b1d60.png)

This PR also adds a new example examples/graphs.hs

![graph](https://user-images.githubusercontent.com/11467473/38509874-78ebeaee-3c23-11e8-8911-2d29725f41c7.png)

This is just a first attempt. There are a lot more thing that can be improved, like 
- better visualizations
- rendering dot files in js
- Adding Closures for function applications (more [here](https://ghc.haskell.org/trac/ghc/wiki/Commentary/Rts/Storage/HeapObjects#Genericapplication)) so that graphs of function application are not generic thunks
- Eliminating Indirections
