### PR TITLE
Examples for Unfolder episode 13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist-newstyle/
 .cabal-sandbox
 .stack-work
 .cabal.sandbox.config
+.envrc

--- a/examples/open_rec_version0.hs
+++ b/examples/open_rec_version0.hs
@@ -1,0 +1,15 @@
+object = (\f -> f (@object f))
+
+mkCounter = (\this -> \n ->
+      Counter (this (add 1 n)) n
+    )
+
+tick = (\c -> case c of {
+      Counter t d -> t
+    })
+
+value = (\c -> case c of {
+      Counter t d -> d
+    })
+
+main = @value (@tick (@tick (@object @mkCounter 0)))

--- a/examples/open_rec_version1.hs
+++ b/examples/open_rec_version1.hs
@@ -1,0 +1,20 @@
+object = (\f -> f (@object f))
+
+mkCounter = (\this -> \n ->
+      Counter (this (add 1 n)) n
+    )
+
+faster = (\this -> \n ->
+      let c = @mkCounter this n
+      in Counter (this (add 2 n)) (@value c)
+    )
+
+tick = (\c -> case c of {
+      Counter t d -> t
+    })
+
+value = (\c -> case c of {
+      Counter t d -> d
+    })
+
+main = @value (@tick (@tick (@object @faster 0)))

--- a/examples/open_rec_version2.hs
+++ b/examples/open_rec_version2.hs
@@ -1,0 +1,24 @@
+object = (\f -> f undefined (@object f))
+
+mkCounter = (\super -> \this -> \n ->
+      Counter (this (add 1 n)) n
+    )
+
+faster = (\super -> \this -> \n ->
+      let c = super n
+      in Counter (this (add 2 n)) (@value c)
+    )
+
+tick = (\c -> case c of {
+      Counter t d -> t
+    })
+
+value = (\c -> case c of {
+      Counter t d -> d
+    })
+
+mixin = (\f -> \g -> \super -> \this ->
+      f (g super this) this
+    )
+
+main = @value (@tick (@tick (@object (@mixin @faster @mkCounter) 0)))

--- a/minimal.html
+++ b/minimal.html
@@ -9,7 +9,6 @@
 <table width="100%" border="1" cellpadding="5" style="border-collapse: collapse;">
 <tr><td><div style="font-family: monospace;" id="cbn_term">Term</div></td></tr>
 <tr><td><div style="font-family: monospace;" id="cbn_heap">Heap</div></td></tr>
-<tr><td><div id="cbn_graph">Graph</div></td></tr>
 </table>
 
 <script type="text/javascript" src="foo.js"></script>

--- a/src/CBN/Options.hs
+++ b/src/CBN/Options.hs
@@ -77,6 +77,10 @@ parseSummarizeOptions = SummarizeOptions
              long "hide-prelude"
            , help "Hide the prelude from the help"
            ])
+    <*> (many $ option str $ mconcat [
+             long "hide-term"
+           , help "Hide specific term from the prelude (can be used multiple times)"
+           ])
     <*> (switch $ mconcat [
              long "hide-gc"
            , help "Hide GC steps"


### PR DESCRIPTION
This also adds a `--hide-term` command line option for hiding specific terms from the prelude.