### PR TITLE
Bump CI to GHC 9.12.1, allow newer containers

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,18 +8,22 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20250104
+# version: 0.19.20250216
 #
-# REGENDATA ("0.19.20250104",["github","visualize-cbn.cabal"])
+# REGENDATA ("0.19.20250216",["github","visualize-cbn.cabal"])
 #
 name: Haskell-CI
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes:
       60
     container:
@@ -38,9 +42,9 @@ jobs:
             compilerVersion: 9.10.1
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.8.2
+          - compiler: ghc-9.8.4
             compilerKind: ghc
-            compilerVersion: 9.8.2
+            compilerVersion: 9.8.4
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.6.6
@@ -81,8 +85,8 @@ jobs:
           chmod a+x "$HOME/.ghcup/bin/ghcup"
       - name: Install cabal-install
         run: |
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.14.1.1 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.14.1.1 -vnormal+nowrap" >> "$GITHUB_ENV"
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.12.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.12.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
       - name: Install GHC (GHCup)
         if: matrix.setup-method == 'ghcup'
         run: |
@@ -185,6 +189,7 @@ jobs:
           echo "package visualize-cbn" >> cabal.project
           echo "    ghc-options: -Werror=missing-methods" >> cabal.project
           cat >> cabal.project <<EOF
+          allow-newer: containers
           EOF
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(visualize-cbn)$/; }' >> cabal.project.local
           cat cabal.project
@@ -220,6 +225,15 @@ jobs:
         run: |
           rm -f cabal.project.local
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
+      - name: prepare for constraint sets
+        run: |
+          rm -f cabal.project.local
+      - name: constraint set containers-0.8
+        run: |
+          $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='containers ^>=0.8' all --dry-run
+          cabal-plan topo | sort
+          $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='containers ^>=0.8' --dependencies-only -j2 all
+          $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='containers ^>=0.8' all
       - name: save cache
         if: always()
         uses: actions/cache/save@v4

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,0 +1,10 @@
+branches: master
+
+constraint-set containers-0.8
+  ghc: >= 8.2
+  constraints: containers ^>=0.8
+  tests: True
+  run-tests: True
+
+raw-project
+  allow-newer: containers

--- a/visualize-cbn.cabal
+++ b/visualize-cbn.cabal
@@ -16,7 +16,7 @@ extra-source-files:  ChangeLog.md README.md CONTRIBUTORS
 tested-with:
   GHC == 9.12.1
   GHC == 9.10.1
-  GHC == 9.8.2
+  GHC == 9.8.4
   GHC == 9.6.6
   GHC == 9.4.8
   GHC == 9.2.8
@@ -58,7 +58,7 @@ executable visualize-cbn
                      , ansi-terminal        >= 1.0  && < 1.2
                      , blaze-html           >= 0.9  && < 0.10
                      , blaze-markup         >= 0.8  && < 0.9
-                     , containers           >= 0.6  && < 0.8
+                     , containers           >= 0.6  && < 1
                      , data-default         >= 0.7  && < 0.9
                      , mtl                  >= 2.2  && < 2.4
                      , optparse-applicative >= 0.18 && < 0.19


### PR DESCRIPTION
- Updated CI to ubuntu-24.04 image (required before 1 April)
- Relaxed `containers` bound.  This package has been producing major yet compatible releases on a higher pace, so I think it makes sense to drop the tight upper bound.  (I also got convinced that this upper bound micro-management is a major distraction in the Haskell ecosystem.)